### PR TITLE
[edit] provide markerPrefix override to conceal local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ npm install --save html-require-loader
 
 #### Configuration
 
-| Option | Description                      | Default                          |
-|--------|----------------------------------|----------------------------------|
-| root   | Root path to look for templates. | Same path as required HTML file. |
+| Option         | Description                         | Default                          |
+|----------------|-------------------------------------|----------------------------------|
+| root           | Root path to look for templates.    | Same path as required HTML file. |
+| markerPrefix   | Prefix override for comment marker. | Same path as required HTML file. |
 
 ```js
 var path = require('path');
@@ -40,7 +41,8 @@ module.exports = {
           {
             loader: 'html-require-loader',
             options: {
-              root: path.resolve(__dirname, 'src')
+              root: path.resolve(__dirname, 'src'),
+              markerPrefix: '/path/to/file'
             }
           }
         ]

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (source) {
     let requireSource = fs.readFileSync(requirePath, 'utf8');
     requires.push(requirePath);
 
-    source = source.replace(match[0], `<!-- <require path="${requirePath}"> -->
+    source = source.replace(match[0], `<!-- <require path="${options.markerPrefix ? options.markerPrefix + match[1].trim() : requirePath}"> -->
 ${requireSource}<!-- </require> -->`);
   }
 


### PR DESCRIPTION
By default, there is no way to conceal the resolved path from the html comment ex.

``` html
<!-- require '/User/chris/documents/dropbox/www/partials/myfile.html'-->
```
I propose having a markerPrefix override to specify your own root prefix that goes in the comment `markerPrefix: dev.mycompany.co/` ex.

``` html
<!-- require 'dev.mycompany.co/partials/myfile.html' -->
```