### PR TITLE
escape windows backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,11 @@ module.exports = function (source) {
     let requireSource = fs.readFileSync(requirePath, 'utf8');
     requires.push(requirePath);
 
-    source = source.replace(match[0], `<!-- <require path="${requirePath}"> -->
+    // Escape windows backslashes to fix a
+    // `Bad escape sequence in untagged template literal` error
+    let escapedRequirePath = requirePath.replace(/\\/g, "\\\\")
+
+    source = source.replace(match[0], `<!-- <require path="${escapedRequirePath}"> -->
 ${requireSource}<!-- </require> -->`);
   }
 


### PR DESCRIPTION
Hey, thanks for this helpful tool! I ran into the same problem as in https://github.com/ngokevin/html-require-loader/issues/1 with Windows, and it looks like it was just an issue with unescaped backslashes from windows paths in the `<!-- <require` comment

Escaping them fixed the issue for me!